### PR TITLE
Implement admin reports and dashboard stats

### DIFF
--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Admin Dashboard</title>
+    <title>The Keeper Of Time - Admin Dashboard</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body>
@@ -14,6 +14,14 @@
         <div class="content">
             <h2>Welcome, {{ current_user.username }}!</h2>
             <p>Select an option from the sidebar to get started.</p>
+
+            <h3>Statistics</h3>
+            <ul>
+                <li>Total Users: {{ user_count }}</li>
+                <li>Total Projects: {{ project_count }}</li>
+                <li>Total Hours Logged: {{ total_hours }}</li>
+                <li>Pending Leave Requests: {{ pending_leave_count }}</li>
+            </ul>
         </div>
     </div>
 </body>

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,14 +2,14 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>{% block title %}Timesheet App{% endblock %}</title>
+    <title>{% block title %}The Keeper Of Time{% endblock %}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
     <!-- Include jQuery for AJAX calls -->
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 </head>
 <body>
     <header>
-        <h1>Timesheet Application</h1>
+        <h1>The Keeper Of Time</h1>
     </header>
     <div class="container">
         {% include 'sidebar.html' %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Timesheet App</title>
+    <title>The Keeper Of Time</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body>
     <header>
-        Welcome to the Timesheet App
+        Welcome to The Keeper Of Time
     </header>
     <div class="container">
         <a href="{{ url_for('login') }}"><button>Login</button></a>

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -1,0 +1,37 @@
+{% extends 'base.html' %}
+
+{% block title %}Reports{% endblock %}
+
+{% block breadcrumb %}
+<nav class="breadcrumb">
+    <a href="{{ url_for('admin_dashboard') }}">Admin Dashboard</a> /
+    <span>Reports</span>
+</nav>
+{% endblock %}
+
+{% block content %}
+<h2>Reports</h2>
+<h3>Total Hours by User</h3>
+<table>
+    <thead>
+        <tr><th>User</th><th>Total Hours</th></tr>
+    </thead>
+    <tbody>
+    {% for username, hours in user_hours %}
+        <tr><td>{{ username }}</td><td>{{ hours or 0 }}</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+
+<h3>Total Hours by Project</h3>
+<table>
+    <thead>
+        <tr><th>Project</th><th>Total Hours</th></tr>
+    </thead>
+    <tbody>
+    {% for name, hours in project_hours %}
+        <tr><td>{{ name }}</td><td>{{ hours or 0 }}</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -8,6 +8,7 @@
             <li><a href="{{ url_for('manage_leave_requests') }}">Manage Leave Requests</a></li>
             <li><a href="{{ url_for('adjust_leave_balances') }}">Adjust Leave Balances</a></li>
             <li><a href="{{ url_for('leave_calendar') }}">Leave Calendar</a></li>
+            <li><a href="{{ url_for('admin_reports') }}">Reports</a></li>
         {% else %}
             <!-- User Sidebar Links -->
             <li><a href="{{ url_for('user_dashboard') }}">Dashboard</a></li>

--- a/templates/user_dashboard.html
+++ b/templates/user_dashboard.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>User Dashboard</title>
+    <title>The Keeper Of Time - User Dashboard</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body>
@@ -14,6 +14,13 @@
         <div class="content">
             <h2>Welcome, {{ current_user.username }}!</h2>
             <p>Select an option from the sidebar to get started.</p>
+
+            <h3>Your Statistics for {{ month_year }}</h3>
+            <ul>
+                <li>Hours logged this month: {{ total_hours_month }}</li>
+                <li>Remaining Leave Balance: {{ remaining_leave }}</li>
+                <li>Upcoming Approved Leave Requests: {{ upcoming_leave }}</li>
+            </ul>
         </div>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- rename site title to **The Keeper Of Time**
- display statistics on admin and user dashboards
- add admin-only reports page to analyze hours by user and project
- show reports link in sidebar

## Testing
- `python -m py_compile timesheet_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6880cae52ec08328a319bfdaf70e9678