### PR TITLE
Implement expandable drill-down reports

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -300,3 +300,9 @@ form textarea {
     max-width: 900px;
     margin: 0 auto;
 }
+
+/* Styles for nested tables used in expandable reports */
+table.nested {
+    margin-top: 10px;
+    width: 100%;
+}

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -12,26 +12,77 @@
 {% block content %}
 <h2>Reports</h2>
 <h3>Total Hours by User</h3>
-<table>
+<table id="user-report">
     <thead>
         <tr><th>User</th><th>Total Hours</th></tr>
     </thead>
     <tbody>
-    {% for username, hours in user_hours %}
-        <tr><td>{{ username }}</td><td>{{ hours or 0 }}</td></tr>
+    {% for uid, username, hours in user_hours %}
+        <tr class="user-row" data-user-id="{{ uid }}">
+            <td>{{ username }}</td>
+            <td>{{ hours or 0 }}</td>
+        </tr>
     {% endfor %}
     </tbody>
 </table>
 
 <h3>Total Hours by Project</h3>
-<table>
+<table id="project-report">
     <thead>
         <tr><th>Project</th><th>Total Hours</th></tr>
     </thead>
     <tbody>
-    {% for name, hours in project_hours %}
-        <tr><td>{{ name }}</td><td>{{ hours or 0 }}</td></tr>
+    {% for pid, name, hours in project_hours %}
+        <tr class="project-row" data-project-id="{{ pid }}">
+            <td>{{ name }}</td>
+            <td>{{ hours or 0 }}</td>
+        </tr>
     {% endfor %}
     </tbody>
 </table>
+
+<script>
+$(function(){
+    // Expand user rows to show project/work package/task breakdown
+    $('#user-report').on('click', '.user-row', function(){
+        const tr = $(this);
+        const userId = tr.data('user-id');
+        let detail = tr.next('.detail-row');
+        if(detail.length){
+            detail.toggle();
+            return;
+        }
+        $.getJSON('/admin_dashboard/reports/user/' + userId, function(data){
+            let rows = '';
+            data.forEach(function(item){
+                rows += '<tr><td>' + item.project + ' / ' + item.work_package + ' / ' + item.task +
+                        '</td><td>' + item.hours + '</td></tr>';
+            });
+            const html = '<tr class="detail-row"><td colspan="2"><table class="nested"><thead><tr><th>Project / WP / Task</th><th>Hours</th></tr></thead><tbody>' +
+                         rows + '</tbody></table></td></tr>';
+            tr.after(html);
+        });
+    });
+
+    // Expand project rows to show work package/task breakdown
+    $('#project-report').on('click', '.project-row', function(){
+        const tr = $(this);
+        const projectId = tr.data('project-id');
+        let detail = tr.next('.detail-row');
+        if(detail.length){
+            detail.toggle();
+            return;
+        }
+        $.getJSON('/admin_dashboard/reports/project/' + projectId, function(data){
+            let rows = '';
+            data.forEach(function(item){
+                rows += '<tr><td>' + item.work_package + ' / ' + item.task + '</td><td>' + item.hours + '</td></tr>';
+            });
+            const html = '<tr class="detail-row"><td colspan="2"><table class="nested"><thead><tr><th>WP / Task</th><th>Hours</th></tr></thead><tbody>' +
+                         rows + '</tbody></table></td></tr>';
+            tr.after(html);
+        });
+    });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add new endpoints to provide detailed hours per user and project
- update report template to load details on click using AJAX
- include basic nested table styling for expandable data

## Testing
- `python -m py_compile timesheet_app.py`
- `python timesheet_app.py & sleep 5; pkill -f timesheet_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6880cec57964832891dc70e7e8c11452