### PR TITLE
Add admin CRUD for dummy test data

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ KeeperOfTime is a small Flask application used to track time on projects and man
 3. Run the application with `python3 timesheet_app.py`.
 
 The default SQLite database is stored in `instance/timesheet_app.db`. On first run an admin account is created with username `admin` and password `admin`.
+Some example "dummy" records are automatically added so you can explore the interface immediately. Administrators can manage these records from the **Dummy Data** page.
 
 ## Development
 

--- a/templates/dummy_data.html
+++ b/templates/dummy_data.html
@@ -1,0 +1,60 @@
+{% extends 'base.html' %}
+
+{% block title %}Dummy Data{% endblock %}
+
+{% block breadcrumb %}
+<nav class="breadcrumb">
+    <a href="{{ url_for('admin_dashboard') }}">Admin Dashboard</a> /
+    <span>Dummy Data</span>
+</nav>
+{% endblock %}
+
+{% block content %}
+<h2>Dummy Data</h2>
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Value</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for item in dummies %}
+        <tr>
+            <form method="POST" action="{{ url_for('dummy_data_page') }}">
+                <input type="hidden" name="action" value="update">
+                <input type="hidden" name="dummy_id" value="{{ item.id }}">
+                <td><input type="text" name="name" value="{{ item.name }}" required></td>
+                <td><input type="text" name="value" value="{{ item.value }}"></td>
+                <td>
+                    <button type="submit">Update</button>
+            </form>
+            <form method="POST" action="{{ url_for('dummy_data_page') }}" style="display:inline;">
+                <input type="hidden" name="action" value="delete">
+                <input type="hidden" name="dummy_id" value="{{ item.id }}">
+                <button type="submit">Delete</button>
+            </form>
+                </td>
+        </tr>
+        {% endfor %}
+        <tr>
+            <form method="POST" action="{{ url_for('dummy_data_page') }}">
+                <input type="hidden" name="action" value="add">
+                <td><input type="text" name="name" placeholder="Name" required></td>
+                <td><input type="text" name="value" placeholder="Value"></td>
+                <td><button type="submit">Add</button></td>
+            </form>
+        </tr>
+    </tbody>
+</table>
+{% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+        <div class="flash-message-container">
+            {% for category, message in messages %}
+                <div class="flash-message {{ category }}">{{ message }}</div>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endwith %}
+{% endblock %}

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -9,6 +9,7 @@
             <li><a href="{{ url_for('adjust_leave_balances') }}">Adjust Leave Balances</a></li>
             <li><a href="{{ url_for('leave_calendar') }}">Leave Calendar</a></li>
             <li><a href="{{ url_for('admin_reports') }}">Reports</a></li>
+            <li><a href="{{ url_for('dummy_data_page') }}">Dummy Data</a></li>
         {% else %}
             <!-- User Sidebar Links -->
             <li><a href="{{ url_for('user_dashboard') }}">Dashboard</a></li>


### PR DESCRIPTION
## Summary
- create `DummyData` model and helper for seeding initial data
- allow administrators to CRUD dummy data records
- add Dummy Data link in the sidebar
- document the feature in the README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6880e31d59148328ba94e5b9a2345721