### PR TITLE
Add example project data

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KeeperOfTime is a small Flask application used to track time on projects and man
 3. Run the application with `python3 timesheet_app.py`.
 
 The default SQLite database is stored in `instance/timesheet_app.db`. On first run an admin account is created with username `admin` and password `admin`.
-Some example "dummy" records are automatically added so you can explore the interface immediately. Administrators can manage these records from the **Dummy Data** page.
+Example projects with sample work packages and tasks are automatically added so you can explore the interface immediately. Administrators can manage these records from the **Dummy Data** page.
 
 ## Development
 

--- a/projects_data.csv
+++ b/projects_data.csv
@@ -1,3 +1,4 @@
 project_name,project_description
-SSENT,Cables
-UKAEA Cycle 1,thing
+Project Alpha,New website launch
+Project Beta,Mobile app development
+Project Gamma,Data analysis pipeline

--- a/projects_data.xml
+++ b/projects_data.xml
@@ -1,13 +1,18 @@
 <?xml version='1.0' encoding='utf-8'?>
 <projects>
   <project>
-    <name>SSENT</name>
-    <description>asdf</description>
+    <name>Project Alpha</name>
+    <description>New website launch</description>
     <tasks />
     </project>
   <project>
-    <name>asdasd</name>
-    <description>asd</description>
+    <name>Project Beta</name>
+    <description>Mobile app development</description>
+    <tasks />
+    </project>
+  <project>
+    <name>Project Gamma</name>
+    <description>Data analysis pipeline</description>
     <tasks />
     </project>
   </projects>

--- a/tasks_data.csv
+++ b/tasks_data.csv
@@ -1,1 +1,7 @@
 project_name,task_name
+Project Alpha,Requirements Gathering
+Project Alpha,Frontend Development
+Project Beta,UI Mockups
+Project Beta,User Testing
+Project Gamma,Acquire Data
+Project Gamma,Build Models

--- a/timesheet_app.py
+++ b/timesheet_app.py
@@ -223,6 +223,69 @@ def init_dummy_data():
         db.session.bulk_save_objects(examples)
         db.session.commit()
 
+def init_example_projects():
+    """Populate the database with example projects, work packages and tasks."""
+    if Project.query.count() == 0:
+        sample_data = [
+            {
+                'name': 'Project Alpha',
+                'description': 'New website launch',
+                'packages': [
+                    {
+                        'name': 'Planning',
+                        'tasks': ['Requirements Gathering', 'Timeline Setup']
+                    },
+                    {
+                        'name': 'Implementation',
+                        'tasks': ['Frontend Development', 'Backend Integration']
+                    }
+                ]
+            },
+            {
+                'name': 'Project Beta',
+                'description': 'Mobile app development',
+                'packages': [
+                    {
+                        'name': 'Design',
+                        'tasks': ['UI Mockups', 'UX Flow']
+                    },
+                    {
+                        'name': 'Testing',
+                        'tasks': ['Unit Tests', 'User Acceptance']
+                    }
+                ]
+            },
+            {
+                'name': 'Project Gamma',
+                'description': 'Data analysis pipeline',
+                'packages': [
+                    {
+                        'name': 'Data Collection',
+                        'tasks': ['Gather Source Data', 'Clean Raw Data']
+                    },
+                    {
+                        'name': 'Modeling',
+                        'tasks': ['Build Models', 'Evaluate Results']
+                    }
+                ]
+            }
+        ]
+
+        for proj in sample_data:
+            project = Project(name=proj['name'], description=proj['description'])
+            db.session.add(project)
+            db.session.flush()  # Ensure project.id is available
+
+            for pkg in proj['packages']:
+                work_package = WorkPackage(name=pkg['name'], project_id=project.id)
+                db.session.add(work_package)
+                db.session.flush()
+                for task_name in pkg['tasks']:
+                    task = Task(name=task_name, work_package_id=work_package.id)
+                    db.session.add(task)
+
+        db.session.commit()
+
 # Helper function to calculate the leave days, accounting for half days.
 def calculate_leave_days(start_date, start_time, end_date, end_time):
     from datetime import timedelta
@@ -1089,6 +1152,9 @@ if __name__ == '__main__':
             admin_user = User(username='admin', password_hash=hashed_password, role='admin')
             db.session.add(admin_user)
             db.session.commit()
+
+        # Create example projects, work packages and tasks on first run
+        init_example_projects()
 
         # Populate dummy data so the UI has content immediately
         init_dummy_data()

--- a/timesheet_data.csv
+++ b/timesheet_data.csv
@@ -1,3 +1,3 @@
-2024-11-18 10:24:12.078203,user,SSENT,2024-11-22,4,hello
-2024-11-18 12:09:40.379526,qwerty,SSENT,2024-11-18,3,wfasdf
-2024-11-18 13:52:27.152685,qwerty,SSENT,2024-11-18,345,345rgtd
+2024-01-10 09:00:00,user,Project Alpha,2024-01-10,2,Initial setup
+2024-01-11 10:30:00,admin,Project Beta,2024-01-11,3,UI design
+2024-01-12 14:00:00,qwerty,Project Gamma,2024-01-12,4,Data analysis


### PR DESCRIPTION
## Summary
- update README to describe sample projects
- reset CSV/XML files with example projects and tasks
- populate database with sample projects, work packages and tasks

## Testing
- `python3 -m py_compile timesheet_app.py`
- `flake8` *(fails: many style warnings)*
- `pip install -r requirements.txt`
- `python3 timesheet_app.py` *(fails: OSError: [Errno 98] Address already in use)*

------
https://chatgpt.com/codex/tasks/task_e_6880e52e23dc83288d5ef541a120ab47