### PR TITLE
Add task start/end dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ KeeperOfTime is a small Flask application used to track time on projects and man
 The default SQLite database is stored in `instance/timesheet_app.db`. On first run an admin account is created with username `admin` and password `admin`.
 Example projects with sample work packages and tasks are automatically added so you can explore the interface immediately. Administrators can manage these records from the **Dummy Data** page.
 
+## Project Management
+
+Tasks now support optional start and end dates. When creating a task under a work package you can specify when the work is scheduled to begin and finish. These dates are visible throughout the admin dashboards to aid basic project planning.
+
 ## Development
 
 Changes to the database schema can be handled via `Flask-Migrate` using the helper script `database_migrate_tool.py`.

--- a/templates/task_detail.html
+++ b/templates/task_detail.html
@@ -13,6 +13,10 @@
 
 {% block content %}
 <h2>Bookings by Users for Task: {{ task.name }}</h2>
+<p>
+    Start: {{ task.start_date or 'N/A' }}<br>
+    End: {{ task.end_date or 'N/A' }}
+</p>
 <table>
     <thead>
         <tr>

--- a/templates/user_task_entries.html
+++ b/templates/user_task_entries.html
@@ -14,6 +14,10 @@
 
 {% block content %}
 <h2>Timesheet Entries for {{ user.username }} on Task: {{ task.name }}</h2>
+<p>
+    Start: {{ task.start_date or 'N/A' }}<br>
+    End: {{ task.end_date or 'N/A' }}
+</p>
 <table>
     <thead>
         <tr>

--- a/templates/work_package_detail.html
+++ b/templates/work_package_detail.html
@@ -16,6 +16,8 @@
     <thead>
         <tr>
             <th>Task Name</th>
+            <th>Start Date</th>
+            <th>End Date</th>
             <th>Total Hours</th>
             <th>Users</th>
             <th>Details</th>
@@ -25,6 +27,8 @@
         {% for item in task_data %}
         <tr>
             <td>{{ item.task.name }}</td>
+            <td>{{ item.task.start_date or '' }}</td>
+            <td>{{ item.task.end_date or '' }}</td>
             <td>{{ item.total_hours }}</td>
             <td>{{ item.users | join(', ') }}</td>
             <td>
@@ -36,6 +40,8 @@
         <tr>
             <form method="POST" action="{{ url_for('work_package_detail', work_package_id=work_package.id) }}">
                 <td><input type="text" name="task_name" placeholder="New Task Name" required></td>
+                <td><input type="date" name="start_date"></td>
+                <td><input type="date" name="end_date"></td>
                 <td colspan="2"></td>
                 <td><button type="submit">Add Task</button></td>
             </form>

--- a/timesheet_app.py
+++ b/timesheet_app.py
@@ -90,6 +90,9 @@ class Task(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), nullable=False)
     work_package_id = db.Column(db.Integer, db.ForeignKey('work_package.id'), nullable=False)
+    # Optional schedule information for basic project management
+    start_date = db.Column(db.Date, nullable=True)
+    end_date = db.Column(db.Date, nullable=True)
 
     timesheets = db.relationship('Timesheet', backref='task', lazy=True)
 
@@ -919,9 +922,19 @@ def work_package_detail(work_package_id):
     if request.method == 'POST':
         # Get form data
         task_name = request.form['task_name']
+        # Optional start and end dates for the task
+        start_str = request.form.get('start_date')
+        end_str = request.form.get('end_date')
+        start_date = datetime.strptime(start_str, '%Y-%m-%d').date() if start_str else None
+        end_date = datetime.strptime(end_str, '%Y-%m-%d').date() if end_str else None
 
-        # Create new task
-        new_task = Task(name=task_name, work_package_id=work_package.id)
+        # Create new task with schedule data
+        new_task = Task(
+            name=task_name,
+            work_package_id=work_package.id,
+            start_date=start_date,
+            end_date=end_date,
+        )
         db.session.add(new_task)
         db.session.commit()
 


### PR DESCRIPTION
## Summary
- add optional start and end dates to Task model
- display schedule info on task details and listings
- allow specifying start/end when creating tasks
- document project management capability in README

## Testing
- `python -m py_compile timesheet_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68811b5d1dcc8328aaeccdc96249d525