### PR TITLE
Add project gantt chart view

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -319,3 +319,9 @@ tr.detail-row {
 tr.level-1 td { padding-left: 20px; }
 tr.level-2 td { padding-left: 40px; }
 tr.level-3 td { padding-left: 60px; }
+
+/* Gantt bar colours based on budget usage */
+.bar-budget-low { fill: #70AD47; }
+.bar-budget-mid { fill: #ff9f38; }
+.bar-budget-high { fill: #e74c3c; }
+

--- a/templates/project_gantt.html
+++ b/templates/project_gantt.html
@@ -1,0 +1,41 @@
+{% extends 'base.html' %}
+{% block title %}Gantt Chart{% endblock %}
+
+{% block breadcrumb %}
+<nav class="breadcrumb">
+    <a href="{{ url_for('projects_page') }}">Projects</a> /
+    <a href="{{ url_for('project_detail', project_id=project.id) }}">Work Packages</a> /
+    <span>Gantt Chart</span>
+</nav>
+{% endblock %}
+
+{% block content %}
+<h2>Gantt Chart - {{ project.name }}</h2>
+<div id="gantt"></div>
+<script src="https://cdn.jsdelivr.net/npm/frappe-gantt@0.5.0/dist/frappe-gantt.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/frappe-gantt@0.5.0/dist/frappe-gantt.css">
+<script>
+    // Tasks data injected from Flask
+    var tasks = {{ tasks|tojson }};
+
+    // Initialise the Gantt chart
+    var gantt = new Gantt("#gantt", tasks, {
+        custom_popup_html: function(task) {
+            return '<div class="details-container">' +
+                   '<b>' + task.name + '</b><br>' +
+                   '<button onclick="editProgress(' + task.id + ',' + task.progress + ')">Edit progress</button>' +
+                   '</div>';
+        }
+    });
+
+    // Prompt for new progress percentage then update via AJAX
+    function editProgress(id, current) {
+        var val = prompt('Enter actual progress (%)', current);
+        if (val === null) return;
+        $.post('{{ url_for('update_task_progress') }}', {
+            task_id: id,
+            progress: val
+        }).done(function(){ location.reload(); });
+    }
+</script>
+{% endblock %}

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -19,6 +19,7 @@
             <th>Total Hours</th>
             <th>Users</th>
             <th>Details</th>
+            <th>Gantt</th>
         </tr>
     </thead>
     <tbody>
@@ -30,6 +31,7 @@
             <td>{{ item.total_hours }}</td>
             <td>{{ item.users | join(', ') }}</td>
             <td><a href="{{ url_for('project_detail', project_id=item.project.id) }}">View Details</a></td>
+            <td><a href="{{ url_for('project_gantt', project_id=item.project.id) }}">Gantt</a></td>
         </tr>
         {% endfor %}
         <!-- Inline Entry Form -->
@@ -38,7 +40,7 @@
                 <td><input type="text" name="project_name" placeholder="New Project Name" required></td>
                 <td><input type="text" name="project_description" placeholder="Description" required></td>
                 <td><input type="number" step="0.1" name="budget_hours" placeholder="Hours"></td>
-                <td colspan="2"></td>
+                <td colspan="3"></td>
                 <td><button type="submit">Add Project</button></td>
             </form>
         </tr>

--- a/timesheet_app.py
+++ b/timesheet_app.py
@@ -70,6 +70,8 @@ def apply_schema_updates():
     add_column('task', 'start_date', 'DATE')
     add_column('task', 'end_date', 'DATE')
     add_column('task', 'budget_hours', 'FLOAT')
+    # Track manually entered progress percentage for each task
+    add_column('task', 'actual_progress', 'FLOAT')
 
 
 
@@ -124,6 +126,8 @@ class Task(db.Model):
     end_date = db.Column(db.Date, nullable=True)
     # Budgeted hours for this task
     budget_hours = db.Column(db.Float, nullable=True)
+    # Actual completion percentage entered by an administrator
+    actual_progress = db.Column(db.Float, nullable=True, default=0)
 
     timesheets = db.relationship('Timesheet', backref='task', lazy=True)
 
@@ -1026,6 +1030,55 @@ def project_detail(project_id):
 
     return render_template('project_detail.html', project=project, wp_data=wp_data)
 
+
+@app.route('/admin_dashboard/projects/<int:project_id>/gantt')
+@admin_required
+def project_gantt(project_id):
+    """Display a Gantt chart for all tasks under a project."""
+    project = Project.query.get_or_404(project_id)
+
+    # Collect each task alongside total hours booked so we can
+    # determine the percentage of its budget that has been spent.
+    entries = (
+        db.session.query(
+            Task,
+            db.func.sum(Timesheet.hours).label('spent')
+        )
+        .join(WorkPackage)
+        .outerjoin(Timesheet, Timesheet.task_id == Task.id)
+        .filter(WorkPackage.project_id == project_id)
+        .group_by(Task.id)
+        .all()
+    )
+
+    # Build the task data structure expected by frappe-gantt
+    tasks = []
+    for task, spent in entries:
+        spent = spent or 0
+        if task.budget_hours and task.budget_hours > 0:
+            percent = (spent / task.budget_hours) * 100
+        else:
+            percent = 0
+
+        # Determine styling class based on budget consumption
+        if percent < 50:
+            cls = 'budget-low'
+        elif percent < 80:
+            cls = 'budget-mid'
+        else:
+            cls = 'budget-high'
+
+        tasks.append({
+            'id': task.id,
+            'name': task.name,
+            'start': (task.start_date or date.today()).isoformat(),
+            'end': (task.end_date or date.today()).isoformat(),
+            'progress': task.actual_progress or 0,
+            'custom_class': cls,
+        })
+
+    return render_template('project_gantt.html', project=project, tasks=tasks)
+
 @app.route('/admin_dashboard/work_packages/<int:work_package_id>', methods=['GET', 'POST'])
 @admin_required
 def work_package_detail(work_package_id):
@@ -1106,6 +1159,19 @@ def user_task_entries(task_id, user_id):
     timesheet_entries = Timesheet.query.filter_by(task_id=task_id, user_id=user_id).all()
 
     return render_template('user_task_entries.html', task=task, user=user, timesheet_entries=timesheet_entries)
+
+
+@app.route('/admin_dashboard/tasks/update_progress', methods=['POST'])
+@admin_required
+def update_task_progress():
+    """Update manually entered progress percentage for a task."""
+    task_id = request.form.get('task_id', type=int)
+    progress = request.form.get('progress', type=float)
+    # Retrieve the task and store the provided progress value
+    task = Task.query.get_or_404(task_id)
+    task.actual_progress = progress
+    db.session.commit()
+    return '', 204
 
 @app.route('/admin_dashboard/users', methods=['GET', 'POST'])
 @admin_required


### PR DESCRIPTION
## Summary
- track task completion percentage in the DB
- display gantt charts per project
- update task progress via AJAX
- link from project table to gantt view
- colour gantt bars based on budget usage

## Testing
- `python3 -m py_compile timesheet_app.py`


------
https://chatgpt.com/codex/tasks/task_e_688160db1b1c83288d60a67c0266df8a