### PR TITLE
Improve Gantt chart layout and show work package overview

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -325,3 +325,36 @@ tr.level-3 td { padding-left: 60px; }
 .bar-budget-mid { fill: #ff9f38; }
 .bar-budget-high { fill: #e74c3c; }
 
+/* Work package bar colours */
+.bar-wp-budget-low { fill: #4a90e2; }
+.bar-wp-budget-mid { fill: #f0ad4e; }
+.bar-wp-budget-high { fill: #d9534f; }
+
+/* Layout for the gantt chart and task list */
+.gantt-container {
+    display: flex;
+    width: 100%;
+}
+
+#task-list {
+    min-width: 200px;
+    background-color: #f8f8f8;
+}
+
+#task-list .task-name {
+    height: 40px;
+    line-height: 40px;
+    padding: 0 10px;
+    border-bottom: 1px solid #ccc;
+}
+
+#task-list .wp-name {
+    font-weight: bold;
+    background-color: #e6e6ff;
+}
+
+#gantt {
+    flex-grow: 1;
+    width: 100%;
+}
+

--- a/templates/project_gantt.html
+++ b/templates/project_gantt.html
@@ -11,7 +11,14 @@
 
 {% block content %}
 <h2>Gantt Chart - {{ project.name }}</h2>
-<div id="gantt"></div>
+<div class="gantt-container">
+    <div id="task-list">
+    {% for item in names %}
+        <div class="task-name{% if item.is_wp %} wp-name{% endif %}">{{ item.label }}</div>
+    {% endfor %}
+    </div>
+    <div id="gantt"></div>
+</div>
 <script src="https://cdn.jsdelivr.net/npm/frappe-gantt@0.5.0/dist/frappe-gantt.min.js"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/frappe-gantt@0.5.0/dist/frappe-gantt.css">
 <script>


### PR DESCRIPTION
## Summary
- enhance project Gantt chart route to aggregate work package data
- add a sidebar list of work packages and tasks
- style the Gantt chart to fill available width
- add distinct colours for work package bars

## Testing
- `python -m py_compile timesheet_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68816312d1608328842a838b9a3bb261