### PR TITLE
Fix gantt layout & add quarter view

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -339,11 +339,13 @@ tr.level-3 td { padding-left: 60px; }
 #task-list {
     min-width: 200px;
     background-color: #f8f8f8;
+    margin-top: 75px; /* offset for gantt header (upper + lower) */
 }
 
+/* Each task row must match the library's row height (bar_height + padding). */
 #task-list .task-name {
-    height: 40px;
-    line-height: 40px;
+    height: 48px;      /* default bar height 30 + padding 18 */
+    line-height: 48px; /* vertically center text within each row */
     padding: 0 10px;
     border-bottom: 1px solid #ccc;
 }

--- a/templates/project_gantt.html
+++ b/templates/project_gantt.html
@@ -11,6 +11,13 @@
 
 {% block content %}
 <h2>Gantt Chart - {{ project.name }}</h2>
+<label for="view-mode-select">View:</label>
+<select id="view-mode-select">
+    <option value="Day">Day</option>
+    <option value="Week">Week</option>
+    <option value="Month">Month</option>
+    <option value="Quarter">Quarter</option>
+</select>
 <div class="gantt-container">
     <div id="task-list">
     {% for item in names %}
@@ -25,14 +32,39 @@
     // Tasks data injected from Flask
     var tasks = {{ tasks|tojson }};
 
-    // Initialise the Gantt chart
+    // Additional view mode showing quarters of the year
+    var quarterView = {
+        name: 'Quarter',
+        padding: '1y',
+        step: '3m',
+        column_width: 120,
+        date_format: 'YYYY-MM',
+        lower_text: function(d) {
+            // Quarter number for lower header
+            return 'Q' + (Math.floor(d.getMonth() / 3) + 1);
+        },
+        upper_text: function(d, ld) {
+            // Display year when it changes
+            return !ld || d.getFullYear() !== ld.getFullYear() ? d.getFullYear() : '';
+        },
+        thick_line: function(d) { return d.getMonth() % 3 === 0; }
+    };
+
+    // Initialise the Gantt chart with view selection enabled
     var gantt = new Gantt("#gantt", tasks, {
+        view_mode_select: true,
+        view_modes: ['Day', 'Week', 'Month', quarterView],
         custom_popup_html: function(task) {
             return '<div class="details-container">' +
                    '<b>' + task.name + '</b><br>' +
                    '<button onclick="editProgress(' + task.id + ',' + task.progress + ')">Edit progress</button>' +
                    '</div>';
         }
+    });
+
+    // Update the chart when the user selects a new view mode
+    document.getElementById('view-mode-select').addEventListener('change', function() {
+        gantt.change_view_mode(this.value);
     });
 
     // Prompt for new progress percentage then update via AJAX


### PR DESCRIPTION
## Summary
- align task titles with chart bars by matching Frappe row height and offsetting for the headers
- add a view selector to switch between day, week, month and quarter views
- implement a custom quarter view mode in the Gantt JavaScript

## Testing
- `python3 -m py_compile timesheet_app.py`
- `python3 -m py_compile database_migrate_tool.py`
- `flake8` *(fails: multiple style violations)*

------
https://chatgpt.com/codex/tasks/task_e_68821b65b6948328ba84f638c03ef7eb