### PR TITLE
Fix mismatched Gantt row heights

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -349,8 +349,14 @@ tr.level-3 td { padding-left: 60px; }
  * prevents extra spacing between the list and the chart bars.
  */
 #task-list .task-name {
-    height: 40px;      /* match gantt row height (20 bar + 20 padding) */
-    line-height: 40px; /* vertically center text within each row */
+    /*
+     * The Gantt library may adjust bar and padding sizes which changes the
+     * overall row height. JavaScript dynamically sets height and line-height
+     * to match the chart after it is initialised. These values act only as a
+     * fallback if scripting fails for any reason.
+     */
+    height: 40px;
+    line-height: 40px;
     padding: 0 10px;
     border-bottom: 1px solid #ccc;
 }

--- a/templates/project_gantt.html
+++ b/templates/project_gantt.html
@@ -62,6 +62,13 @@
         }
     });
 
+    // Adjust task list row heights to exactly match the Gantt chart rows
+    var rowHeight = gantt.options.bar_height + gantt.options.padding;
+    document.querySelectorAll('#task-list .task-name').forEach(function(el) {
+        el.style.height = rowHeight + 'px';
+        el.style.lineHeight = rowHeight + 'px';
+    });
+
     // Update the chart when the user selects a new view mode
     document.getElementById('view-mode-select').addEventListener('change', function() {
         gantt.change_view_mode(this.value);


### PR DESCRIPTION
## Summary
- ensure label rows match Frappe Gantt row height
- sync row height via JavaScript

## Testing
- `python3 -m py_compile timesheet_app.py database_migrate_tool.py`

------
https://chatgpt.com/codex/tasks/task_e_68822574983c83288b882ac4714f6c12