### PR TITLE
Add RPi hosting script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ KeeperOfTime is a small Flask application used to track time on projects and man
 The default SQLite database is stored in `instance/timesheet_app.db`. On first run an admin account is created with username `admin` and password `admin`.
 Example projects with sample work packages and tasks are automatically added so you can explore the interface immediately. Administrators can manage these records from the **Dummy Data** page. When dummy projects are created through this page each task is given a simple start and end date along with budget hours so reports show meaningful schedules from the outset.
 
+## Hosting on Raspberry Pi
+
+Use the `rpi_server.py` helper script to run the application on a Raspberry Pi.
+Specify an optional port number when launching the script:
+
+```bash
+python3 rpi_server.py 8080  # listens on port 8080
+```
+
+If no port argument is provided the server defaults to `8000`.
+
 ## Project Management
 
 Tasks now support optional start and end dates. When creating a task under a work package you can specify when the work is scheduled to begin and finish. These dates are visible throughout the admin dashboards to aid basic project planning.

--- a/rpi_server.py
+++ b/rpi_server.py
@@ -1,0 +1,67 @@
+"""Simple script to host KeeperOfTime on a Raspberry Pi using Waitress.
+
+Usage:
+    python3 rpi_server.py [PORT]
+
+If PORT is omitted it defaults to 8000.
+"""
+
+import sys
+from waitress import serve
+
+# Import the Flask application and helpers from the main app module
+from timesheet_app import (
+    app,
+    db,
+    apply_schema_updates,
+    User,
+    generate_password_hash,
+    init_example_projects,
+    init_dummy_data,
+)
+
+
+def initialize_database():
+    """Ensure the SQLite database exists and has sample data."""
+    # Apply schema updates for older installations
+    apply_schema_updates()
+
+    # Create missing tables
+    db.create_all()
+
+    # Create the default admin user if not present
+    if not User.query.filter_by(username="admin").first():
+        hashed_password = generate_password_hash("admin")
+        admin_user = User(
+            username="admin", password_hash=hashed_password, role="admin"
+        )
+        db.session.add(admin_user)
+        db.session.commit()
+
+    # Populate example projects and dummy data on first run
+    init_example_projects()
+    init_dummy_data()
+
+
+def main() -> None:
+    """Entry point when executing the script."""
+    # Default port if none is supplied via command line
+    port = 8000
+
+    # Attempt to read an integer port from the first argument
+    if len(sys.argv) > 1:
+        try:
+            port = int(sys.argv[1])
+        except ValueError:
+            print(f"Invalid port '{sys.argv[1]}', falling back to {port}.")
+
+    # Perform database initialization within the application context
+    with app.app_context():
+        initialize_database()
+
+    # Start the Waitress WSGI server
+    serve(app, host="0.0.0.0", port=port)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `rpi_server.py` for running KeeperOfTime on a Raspberry Pi
- document Raspberry Pi usage in the README

## Testing
- `python3 -m py_compile rpi_server.py`
- `python3 -m py_compile timesheet_app.py`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6884b3e89f78832894adf5c407a71de3