### PR TITLE
Add navbar profile menu and placeholder profile pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,45 @@ KeeperOfTime is a small Flask application used to track time on projects and man
 ## Setup
 
 1. Create and activate a Python virtual environment.
+
+   **Linux / Raspberry Pi**
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+
+   **Windows**
+   ```powershell
+   python -m venv .venv
+   .venv\Scripts\activate
+   ```
+
 2. Install dependencies using:
    ```bash
-   python -m pip install -r requirements.txt
+   pip install -r requirements.txt
    ```
-3. Run the application with `python3 timesheet_app.py`.
+
+3. Run the application:
+
+   ```bash
+   python3 timesheet_app.py
+   ```
+
+   To change the port or switch to the Flask development server, set the following environment variables before running:
+
+   **Linux / Raspberry Pi**
+   ```bash
+   export KOT_PORT=5000          # optional port number
+   export KOT_PRODUCTION=false   # use Flask's debug server
+   python3 timesheet_app.py
+   ```
+
+   **Windows**
+   ```powershell
+   set KOT_PORT=5000
+   set KOT_PRODUCTION=false
+   python timesheet_app.py
+   ```
 
 The default SQLite database is stored in `instance/timesheet_app.db`. On first run an admin account is created with username `admin` and password `admin`.
 Example projects with sample work packages and tasks are automatically added so you can explore the interface immediately. Administrators can manage these records from the **Dummy Data** page. When dummy projects are created through this page each task is given a simple start and end date along with budget hours so reports show meaningful schedules from the outset.

--- a/static/styles.css
+++ b/static/styles.css
@@ -10,8 +10,64 @@ body {
 header {
     background-color: #064b6a; /* Blue */
     color: #FFFFFF; /* White */
-    padding: 15px;
-    text-align: center;
+    padding: 0;
+}
+
+/* Top navigation bar */
+.navbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 20px;
+}
+
+.navbar h1 {
+    margin: 0;
+    font-size: 24px;
+}
+
+/* Profile button and dropdown */
+.profile-menu {
+    position: relative;
+    display: inline-block;
+}
+
+.profile-button {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: #ff8f48; /* Orange */
+    color: #FFFFFF; /* White */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    font-weight: bold;
+}
+
+.dropdown-content {
+    display: none;
+    position: absolute;
+    right: 0;
+    background-color: #FFFFFF; /* White */
+    min-width: 200px;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    z-index: 1;
+}
+
+.dropdown-content a {
+    color: #000000; /* Black */
+    padding: 12px 16px;
+    text-decoration: none;
+    display: block;
+}
+
+.dropdown-content a:hover {
+    background-color: #f1f1f1; /* Light grey */
+}
+
+.dropdown-content.show {
+    display: block;
 }
 
 .container {

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,32 @@
 </head>
 <body>
     <header>
-        <h1>The Keeper Of Time</h1>
+        <nav class="navbar">
+            <div class="navbar-left">
+                <h1>The Keeper Of Time</h1>
+            </div>
+            <div class="navbar-right">
+                {% if current_user.is_authenticated %}
+                <div class="profile-menu">
+                    <!-- Circle with user's initial acts as profile picture -->
+                    <div class="profile-button" id="profileMenuButton">
+                        {{ current_user.username[0]|upper }}
+                    </div>
+                    <!-- Dropdown menu with profile actions -->
+                    <div class="dropdown-content" id="profileDropdown">
+                        <a href="{{ url_for('manage_profiles') }}">Manage Profiles</a>
+                        <a href="{{ url_for('learning_zone') }}">Learning Zone</a>
+                        <a href="{{ url_for('my_details') }}">My Details</a>
+                        <a href="{{ url_for('subscription_details') }}">Subscription Details</a>
+                        {% if current_user.role == 'admin' %}
+                        <a href="{{ url_for('users_page') }}">Manage Users</a>
+                        {% endif %}
+                        <a href="{{ url_for('logout') }}">Sign out</a>
+                    </div>
+                </div>
+                {% endif %}
+            </div>
+        </nav>
     </header>
     <div class="container">
         {% include 'sidebar.html' %}
@@ -30,5 +55,21 @@
             {% endblock %}
         </div>
     </div>
+    <!-- Simple script to toggle profile dropdown and close when clicking away -->
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const button = document.getElementById('profileMenuButton');
+            const dropdown = document.getElementById('profileDropdown');
+            if (button) {
+                button.addEventListener('click', function(event) {
+                    event.stopPropagation();
+                    dropdown.classList.toggle('show');
+                });
+                window.addEventListener('click', function() {
+                    dropdown.classList.remove('show');
+                });
+            }
+        });
+    </script>
 </body>
 </html>

--- a/templates/learning_zone.html
+++ b/templates/learning_zone.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+
+{% block title %}Learning Zone{% endblock %}
+
+{% block breadcrumb %}
+<nav class="breadcrumb">
+    <span>Learning Zone</span>
+</nav>
+{% endblock %}
+
+{% block content %}
+<h2>Learning Zone</h2>
+<p>Training materials and helpful resources will be listed here. Explore upcoming lessons and documentation.</p>
+{% endblock %}

--- a/templates/manage_profiles.html
+++ b/templates/manage_profiles.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+
+{% block title %}Manage Profiles{% endblock %}
+
+{% block breadcrumb %}
+<nav class="breadcrumb">
+    <span>Manage Profiles</span>
+</nav>
+{% endblock %}
+
+{% block content %}
+<h2>Manage Profiles</h2>
+<p>Use this page to view and edit your profile information. Further options will appear here as development continues.</p>
+{% endblock %}

--- a/templates/my_details.html
+++ b/templates/my_details.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+
+{% block title %}My Details{% endblock %}
+
+{% block breadcrumb %}
+<nav class="breadcrumb">
+    <span>My Details</span>
+</nav>
+{% endblock %}
+
+{% block content %}
+<h2>My Details</h2>
+<p>Your personal account information is shown below. Update options will be made available soon.</p>
+{% endblock %}

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -16,7 +16,6 @@
             <li><a href="{{ url_for('timesheets_page') }}">Timesheets</a></li>
             <li><a href="{{ url_for('user_leave_dashboard') }}">Annual Leave</a></li>
         {% endif %}
-        <li><a href="{{ url_for('logout') }}">Logout</a></li>
     {% else %}
         <li><a href="{{ url_for('login') }}">Login</a></li>
     {% endif %}

--- a/templates/subscription_details.html
+++ b/templates/subscription_details.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+
+{% block title %}Subscription Details{% endblock %}
+
+{% block breadcrumb %}
+<nav class="breadcrumb">
+    <span>Subscription Details</span>
+</nav>
+{% endblock %}
+
+{% block content %}
+<h2>Subscription Details</h2>
+<p>View information about your current subscription. Billing and plan management features will appear here.</p>
+{% endblock %}

--- a/timesheet_app.py
+++ b/timesheet_app.py
@@ -572,6 +572,38 @@ def logout():
     logout_user()
     return redirect(url_for('index'))
 
+
+@app.route('/profile/manage_profiles')
+@login_required
+def manage_profiles():
+    """Page for users to manage their profile settings."""
+    app.logger.debug("%s opened Manage Profiles", current_user.username)
+    return render_template('manage_profiles.html')
+
+
+@app.route('/profile/learning_zone')
+@login_required
+def learning_zone():
+    """Placeholder page for training materials."""
+    app.logger.debug("%s opened Learning Zone", current_user.username)
+    return render_template('learning_zone.html')
+
+
+@app.route('/profile/my_details')
+@login_required
+def my_details():
+    """Display current user's account details."""
+    app.logger.debug("%s opened My Details", current_user.username)
+    return render_template('my_details.html')
+
+
+@app.route('/profile/subscription')
+@login_required
+def subscription_details():
+    """Show subscription information for the current user."""
+    app.logger.debug("%s opened Subscription Details", current_user.username)
+    return render_template('subscription_details.html')
+
 @app.route('/user_dashboard')
 @login_required
 def user_dashboard():
@@ -1554,6 +1586,13 @@ if __name__ == '__main__':
         # Populate dummy data so the UI has content immediately
         init_dummy_data()
 
-    #app.run(debug=True)
-    #app.run(host='0.0.0.0', port=5000, debug=False, threaded=False)
-    serve(app, host='0.0.0.0', port=8000)
+    # Determine runtime configuration
+    port = int(os.environ.get('KOT_PORT', 8000))
+    use_production = os.environ.get('KOT_PRODUCTION', 'true').lower() == 'true'
+
+    if use_production:
+        # Use Waitress for a production-ready server
+        serve(app, host='0.0.0.0', port=port)
+    else:
+        # Development server with debug output for easier troubleshooting
+        app.run(host='0.0.0.0', port=port, debug=True)


### PR DESCRIPTION
## Summary
- Introduce top navbar with profile button and dropdown for profile-related actions.
- Add placeholder pages for profile management, learning resources, personal details, and subscription information.
- Allow server port and production mode to be configured via environment variables.

## Testing
- `python -m py_compile timesheet_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6892079b83b083288dee115eca58ac0b